### PR TITLE
Endpint get product by id

### DIFF
--- a/commerce/views.py
+++ b/commerce/views.py
@@ -6,19 +6,19 @@ from .serializers import PedidoSerializer, DetallePedidoSerializer, PagoSerializ
 class PedidoViewSet(viewsets.ModelViewSet):
     queryset = Pedido.objects.all()
     serializer_class = PedidoSerializer
-    #permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticated]
 
 class DetallePedidoViewSet(viewsets.ModelViewSet):
     queryset = DetallePedido.objects.all()
     serializer_class = DetallePedidoSerializer
-    #permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticated]
 
 class PagoViewSet(viewsets.ModelViewSet):
     queryset = Pago.objects.all()
     serializer_class = PagoSerializer
-    #permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticated]
 
 class EnvioViewSet(viewsets.ModelViewSet):
     queryset = Envio.objects.all()
     serializer_class = EnvioSerializer
-    #permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticated]

--- a/commerce/views.py
+++ b/commerce/views.py
@@ -6,19 +6,19 @@ from .serializers import PedidoSerializer, DetallePedidoSerializer, PagoSerializ
 class PedidoViewSet(viewsets.ModelViewSet):
     queryset = Pedido.objects.all()
     serializer_class = PedidoSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    #permission_classes = [permissions.IsAuthenticated]
 
 class DetallePedidoViewSet(viewsets.ModelViewSet):
     queryset = DetallePedido.objects.all()
     serializer_class = DetallePedidoSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    #permission_classes = [permissions.IsAuthenticated]
 
 class PagoViewSet(viewsets.ModelViewSet):
     queryset = Pago.objects.all()
     serializer_class = PagoSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    #permission_classes = [permissions.IsAuthenticated]
 
 class EnvioViewSet(viewsets.ModelViewSet):
     queryset = Envio.objects.all()
     serializer_class = EnvioSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    #permission_classes = [permissions.IsAuthenticated]

--- a/products/urls.py
+++ b/products/urls.py
@@ -1,5 +1,5 @@
 from django.urls import include, path
-from .views import ProductosConImagenView, ProductoViewSet, CategoriaViewSet, PostViewSet, ImagenProductoViewSet
+from .views import ProductosConImagenView, ProductoViewSet, CategoriaViewSet, PostViewSet, ImagenProductoViewSet, ProductoDetalleView
 from django.conf.urls.static import static
 from django.conf import settings
 from rest_framework import routers, permissions
@@ -14,5 +14,6 @@ router.register(r'imagenes_productos', ImagenProductoViewSet)
 urlpatterns = [
     path('', include(router.urls)),
     path('productos-con-imagenes/', ProductosConImagenView.as_view(), name='productos-con-imagenes'),
+    path('producto-detalle/<int:pk>/', ProductoDetalleView.as_view({'get': 'retrieve'}), name='producto-detalle'),
 ]
 

--- a/products/views.py
+++ b/products/views.py
@@ -15,7 +15,7 @@ class ProductoViewSet(viewsets.ModelViewSet):
 class CategoriaViewSet(viewsets.ModelViewSet):
     queryset = Categoria.objects.all()
     serializer_class = CategoriaSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    #permission_classes = [permissions.IsAuthenticated]
 
 class PostViewSet(viewsets.ModelViewSet):
     queryset = Post.objects.all()
@@ -31,3 +31,14 @@ class ProductosConImagenView(APIView):
         serializer = ProductoConImagenSerializer(productos, many=True)
         return Response(serializer.data)
 
+class ProductoDetalleView(viewsets.ModelViewSet):
+    queryset = Producto.objects.all()
+    serializer_class = ProductoConImagenSerializer
+
+    def retrieve(self, request, pk=None):
+        try:
+            producto = self.get_object()
+            serializer = self.get_serializer(producto)
+            return Response(serializer.data)
+        except Producto.DoesNotExist:
+            return Response({"message": "Producto no encontrado."})

--- a/products/views.py
+++ b/products/views.py
@@ -15,7 +15,7 @@ class ProductoViewSet(viewsets.ModelViewSet):
 class CategoriaViewSet(viewsets.ModelViewSet):
     queryset = Categoria.objects.all()
     serializer_class = CategoriaSerializer
-    #permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticated]
 
 class PostViewSet(viewsets.ModelViewSet):
     queryset = Post.objects.all()


### PR DESCRIPTION
# Endpoint get product by id product
Se crea una `view` para traer el detalle de un producto en específico, se sigue usando el `serializer` de `get-product-image`.

# Nota
Hay que comentariazar `CategoriaViewSet` de producto para que no pida autorización y deje funcionar correctamente.

## Endpoint
http://127.0.0.1:8000/api/productos/producto-detalle/id/
`id` se cambia por él, id del producto a obtener el detalle

## JSON
![imagen](https://github.com/user-attachments/assets/d3a483eb-43dc-4acd-a97f-9e5e33a04afe)

## DOCS
https://www.django-rest-framework.org/api-guide/viewsets/

