### PR TITLE
Add dashboard product creation endpoint

### DIFF
--- a/products/tests.py
+++ b/products/tests.py
@@ -1,3 +1,31 @@
-from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
 
-# Create your tests here.
+from users.models import Usuario
+from .models import Post
+
+
+class DashboardCreateProductTests(APITestCase):
+    def setUp(self):
+        self.user = Usuario.objects.create_user(
+            username="testuser", password="testpass123"
+        )
+
+    def test_product_created_in_review_state(self):
+        self.client.force_authenticate(user=self.user)
+        url = reverse("dashboard-create-product")
+        data = {
+            "nombre": "Producto de prueba",
+            "descripcion": "Descripcion",
+            "precio": "10.00",
+            "stock": 3,
+        }
+        response = self.client.post(url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        post = Post.objects.get(id_post=response.data["id_post"])
+        self.assertEqual(post.estado, "revisión")
+        self.assertEqual(post.mensaje, "En revisión")
+

--- a/products/urls.py
+++ b/products/urls.py
@@ -1,5 +1,13 @@
 from django.urls import include, path
-from .views import ProductosConImagenView, ProductoViewSet, CategoriaViewSet, PostViewSet, ImagenProductoViewSet, ProductoDetalleView
+from .views import (
+    ProductosConImagenView,
+    ProductoViewSet,
+    CategoriaViewSet,
+    PostViewSet,
+    ImagenProductoViewSet,
+    ProductoDetalleView,
+    DashboardCreateProductView,
+)
 from django.conf.urls.static import static
 from django.conf import settings
 from rest_framework import routers, permissions
@@ -15,5 +23,6 @@ urlpatterns = [
     path('', include(router.urls)),
     path('productos-con-imagenes/', ProductosConImagenView.as_view(), name='productos-con-imagenes'),
     path('producto-detalle/<int:pk>/', ProductoDetalleView.as_view({'get': 'retrieve'}), name='producto-detalle'),
+    path('dashboard/create-product/', DashboardCreateProductView.as_view(), name='dashboard-create-product'),
 ]
 

--- a/products/views.py
+++ b/products/views.py
@@ -53,3 +53,27 @@ class ProductoDetalleView(viewsets.ModelViewSet):
             return Response(serializer.data)
         except Producto.DoesNotExist:
             return Response({"message": "Producto no encontrado."})
+
+
+class DashboardCreateProductView(generics.CreateAPIView):
+    """Create a Post from the dashboard with default review state."""
+
+    queryset = Post.objects.all()
+    serializer_class = PostCreateSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def create(self, request, *args, **kwargs):
+        data = request.data.copy()
+        data["id_usuario"] = request.user.id
+        serializer = self.get_serializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+    def perform_create(self, serializer):
+        serializer.save(
+            id_usuario=self.request.user,
+            estado="revisión",
+            mensaje="En revisión",
+        )


### PR DESCRIPTION
## Summary
- add dashboard API for creating product posts in "En revisión" state
- expose endpoint in products URLs
- test dashboard product creation remains in review state

## Testing
- `DJANGO_SECRET_KEY=testsecret python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a2409c17208331a1b7b6171758e58c