### PR TITLE
Add admin-protected product dashboard

### DIFF
--- a/autoctonos/settings.py
+++ b/autoctonos/settings.py
@@ -165,3 +165,13 @@ CORS_ALLOWED_ORIGINS = [
     "http://localhost:4321",
     "http://127.0.0.1:4321"
 ]
+
+if os.environ.get("DISABLE_MIGRATIONS"):
+    class DisableMigrations(dict):
+        def __contains__(self, item):
+            return True
+
+        def __getitem__(self, item):
+            return None
+
+    MIGRATION_MODULES = DisableMigrations()

--- a/autoctonos/urls.py
+++ b/autoctonos/urls.py
@@ -9,7 +9,7 @@ from drf_yasg.views import get_schema_view
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from django.conf.urls.static import static
 from django.conf import settings
-from products import urls as product_url 
+from products import urls as product_url
 from users import urls as user_url
 from commerce import urls as commerce_url
 
@@ -36,7 +36,8 @@ urlpatterns = [
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('api/productos/', include(product_url)),
     path('api/users/', include(user_url)),
-    path('api/commerce/', include(commerce_url))
+    path('api/commerce/', include(commerce_url)),
+    path('dashboard/', products_views.product_dashboard, name='product-dashboard'),
 ]
 
 if settings.DEBUG:

--- a/products/forms.py
+++ b/products/forms.py
@@ -1,0 +1,10 @@
+from django import forms
+from .models import Producto
+
+class ProductoForm(forms.ModelForm):
+    class Meta:
+        model = Producto
+        fields = ['id_categoria', 'nombre', 'descripcion', 'precio', 'stock', 'estado']
+        widgets = {
+            'descripcion': forms.Textarea(attrs={'rows': 4}),
+        }

--- a/products/templates/products/dashboard.html
+++ b/products/templates/products/dashboard.html
@@ -1,0 +1,54 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Product Dashboard</title>
+    <style>
+        body { font-family: Arial, sans-serif; background-color: #f4f4f4; }
+        .container { max-width: 800px; margin: 40px auto; background: #fff; padding: 20px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        h1 { text-align: center; color: #333; }
+        form { margin-bottom: 30px; }
+        label { display: block; margin-top: 10px; }
+        input, select, textarea { width: 100%; padding: 8px; margin-top: 5px; border: 1px solid #ccc; border-radius: 4px; }
+        button { margin-top: 15px; padding: 10px 15px; background-color: #4CAF50; color: white; border: none; border-radius: 4px; cursor: pointer; }
+        button:hover { background-color: #45a049; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { padding: 10px; border-bottom: 1px solid #ddd; text-align: left; }
+        th { background-color: #f2f2f2; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Product Dashboard</h1>
+        <form method="post">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <button type="submit">Add Product</button>
+        </form>
+        <h2>Existing Products</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Category</th>
+                    <th>Price</th>
+                    <th>Stock</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for producto in productos %}
+                <tr>
+                    <td>{{ producto.nombre }}</td>
+                    <td>{{ producto.id_categoria.nombre }}</td>
+                    <td>{{ producto.precio }}</td>
+                    <td>{{ producto.stock }}</td>
+                </tr>
+            {% empty %}
+                <tr><td colspan="4">No products yet.</td></tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</body>
+</html>

--- a/products/tests.py
+++ b/products/tests.py
@@ -1,3 +1,22 @@
 from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
 
-# Create your tests here.
+
+class ProductDashboardTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username='admin', password='pass', is_staff=True
+        )
+
+    def test_dashboard_requires_login(self):
+        response = self.client.get(reverse('product-dashboard'))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/admin/login/', response.url)
+
+    def test_dashboard_loads_for_staff(self):
+        self.client.login(username='admin', password='pass')
+        response = self.client.get(reverse('product-dashboard'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Product Dashboard')

--- a/products/views.py
+++ b/products/views.py
@@ -1,13 +1,20 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from rest_framework import viewsets, permissions
 from .models import Producto, Categoria, ImagenProducto
-from .serializers import ProductoConImagenSerializer, ProductoSerializer, CategoriaSerializer, ImagenProductoSerializer
+from .serializers import (
+    ProductoConImagenSerializer,
+    ProductoSerializer,
+    CategoriaSerializer,
+    ImagenProductoSerializer,
+)
 from rest_framework.decorators import api_view
-from rest_framework.response import Response 
+from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework import generics
 from django.db.models import Q
+from django.contrib.auth.decorators import login_required, user_passes_test
+from .forms import ProductoForm
 
 class ProductoViewSet(viewsets.ModelViewSet):
     queryset = Producto.objects.all()
@@ -53,3 +60,27 @@ class ProductosCategoriaView(APIView):
 
         serializer = ProductoConImagenSerializer(qs, many=True)  # ← NO tocamos lógica de imágenes
         return Response(serializer.data)
+
+
+def staff_check(user):
+    return user.is_staff
+
+
+@login_required(login_url='/admin/login/')
+@user_passes_test(staff_check)
+def product_dashboard(request):
+    """Simple dashboard to add and list products."""
+    if request.method == 'POST':
+        form = ProductoForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect('product-dashboard')
+    else:
+        form = ProductoForm()
+
+    productos = Producto.objects.all()
+    context = {
+        'form': form,
+        'productos': productos,
+    }
+    return render(request, 'products/dashboard.html', context)


### PR DESCRIPTION
## Summary
- Add `ProductoForm` and HTML template for a simple product dashboard
- Implement admin-only dashboard view for creating and listing products
- Expose dashboard at `/dashboard/` and include basic tests
- Allow disabling migrations via `DISABLE_MIGRATIONS` for test environments

## Testing
- `DISABLE_MIGRATIONS=1 DJANGO_SECRET_KEY=foo python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a2484b961883318f09ae3208a563cc