### PR TITLE
Restrict dashboard to admins and enable image uploads

### DIFF
--- a/products/admin.py
+++ b/products/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Post
+from .models import Post, Producto, Categoria, ImagenProducto
 
 @admin.action(description="Aprobar posts seleccionados")
 def aprobar_posts(modeladmin, request, queryset):
@@ -12,11 +12,20 @@ def rechazar_posts(modeladmin, request, queryset):
         post.mensaje = "Rechazado por el administrador" 
         post.save()
 
+class ImagenProductoInline(admin.TabularInline):
+    model = ImagenProducto
+    extra = 1
+
+
 class PostAdmin(admin.ModelAdmin):
     list_display = ('nombre', 'id_usuario', 'estado', 'created_at')
     list_filter = ('estado', 'created_at')
     search_fields = ('nombre', 'descripcion')
     actions = [aprobar_posts, rechazar_posts]
+    inlines = [ImagenProductoInline]
 
 admin.site.register(Post, PostAdmin)
+admin.site.register(Producto)
+admin.site.register(Categoria)
+admin.site.register(ImagenProducto)
 

--- a/products/views.py
+++ b/products/views.py
@@ -1,9 +1,17 @@
 from django.shortcuts import render
 from rest_framework import viewsets, permissions
+from rest_framework.parsers import MultiPartParser, FormParser
 from .models import Producto, Categoria, Post, ImagenProducto
-from .serializers import ProductoConImagenSerializer, PostCreateSerializer, ProductoSerializer, CategoriaSerializer, PostSerializer, ImagenProductoSerializer
+from .serializers import (
+    ProductoConImagenSerializer,
+    PostCreateSerializer,
+    ProductoSerializer,
+    CategoriaSerializer,
+    PostSerializer,
+    ImagenProductoSerializer,
+)
 from rest_framework.decorators import api_view
-from rest_framework.response import Response 
+from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework import generics
@@ -11,13 +19,16 @@ from rest_framework import generics
 class ProductoViewSet(viewsets.ModelViewSet):
     queryset = Producto.objects.all()
     serializer_class = ProductoSerializer
+    permission_classes = [permissions.IsAdminUser]
 
 class CategoriaViewSet(viewsets.ModelViewSet):
     queryset = Categoria.objects.all()
     serializer_class = CategoriaSerializer
+    permission_classes = [permissions.IsAdminUser]
 
 class PostViewSet(viewsets.ModelViewSet):
-    queryset = Post.objects.all() 
+    queryset = Post.objects.all()
+    permission_classes = [permissions.IsAdminUser]
     
     def get_queryset(self):
         queryset = super().get_queryset()
@@ -35,6 +46,8 @@ class PostViewSet(viewsets.ModelViewSet):
 class ImagenProductoViewSet(viewsets.ModelViewSet):
     queryset = ImagenProducto.objects.all()
     serializer_class = ImagenProductoSerializer
+    permission_classes = [permissions.IsAdminUser]
+    parser_classes = [MultiPartParser, FormParser]
 
 class ProductosConImagenView(APIView):
     def get(self, request):
@@ -45,6 +58,7 @@ class ProductosConImagenView(APIView):
 class ProductoDetalleView(viewsets.ModelViewSet):
     queryset = Producto.objects.all()
     serializer_class = ProductoConImagenSerializer
+    permission_classes = [permissions.IsAdminUser]
 
     def retrieve(self, request, pk=None):
         try:


### PR DESCRIPTION
## Summary
- allow admins to upload and edit product images from the dashboard
- restrict product-related viewsets and endpoints to admin users

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a24b7dfa508331996d9a81daa1234f